### PR TITLE
Use word boundary in lookup pattern

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
 import postcss from 'postcss';
 
 const plugin = 'postcss-property-lookup';
-const lookupPattern = /@([a-z-]+)(\s?)/g;
+const lookupPattern = /@([a-z-]+)\b/g;
 const defaultOptions = {
   logLevel: 'warn'
 };
@@ -37,14 +37,14 @@ function propertyLookup(options = defaultOptions) {
       });
     });
 
-    function resolveLookup(rule, orig, prop, space) {
+    function resolveLookup(rule, orig, prop) {
       const resolvedValue = closest(rule, prop);
 
       if (!resolvedValue) {
         log(`Unable to find property ${orig} in ${rule.selector}`, rule, result);
       }
 
-      return resolvedValue + space;
+      return resolvedValue;
     }
 
     function closest(container, prop) {


### PR DESCRIPTION
@simonsmith this neither adds or removes functionality, so it shouldn't require a release; however, it definitely simplifies (slightly) how the regular expression works by using a word boundary `\b` instead of an extra capture group `(\s)?`.