### PR TITLE
Add support for Visual Studio Code with TypeScript definition file

### DIFF
--- a/.d.ts
+++ b/.d.ts
@@ -1,0 +1,17 @@
+/// <reference path="node_modules/postcss/postcss.d.ts" />
+
+declare module 'postcss-property-lookup' {
+  import postcss from 'postcss';
+  var _default: postcss.Plugin<PostCssPropertyLookup.Options>;
+  export default _default;
+  export module PostCssPropertyLookup {
+    interface Options {
+      /**
+       * When a lookup cannot be resolved, this specifies whether to throw an
+       * error or log a warning. In the case of a warning, the invalid lookup
+       * value will be replaced with an empty string.
+       */
+       logLevel?: string;
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -35,6 +35,35 @@ postcss([ require('postcss-property-lookup') ])
 
 See [PostCSS] docs for examples for your environment.
 
+## Installation
+
+```
+$ npm install postcss-property-lookup
+```
+
+## Usage
+
+### JavaScript
+
+```js
+postcss([
+  require('postcss-property-lookup')(/* options */),
+  // more plugins...
+])
+```
+
+### TypeScript
+
+```ts
+///<reference path="node_modules/postcss-property-lookup/.d.ts" />
+import postcssPropertyLookup from 'postcss-property-lookup';
+
+postcss([
+  postcssPropertyLookup(/* options */),
+  // more plugins...
+])
+```
+
 ## Options
 
 ### logLevel

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "target": "ES6"
+  }
+}


### PR DESCRIPTION
Without converting the source code into TypeScript, this PR adds support for [Visual Studio Code](https://code.visualstudio.com/), available also on [Linux and OS X](https://code.visualstudio.com/#alt-downloads), by exposing a `.d.ts` type definition file. Inside this file, the plugin options are exposed so that developers can know which plugins are supported directly in-editor instead of looking up the documentation online.

The `jsconfig.json` file tells Visual Studio Code that the source code for this project is compiled into ES6, so it doesn't underline everything in red in the editor.

![typescript](https://cloud.githubusercontent.com/assets/1058243/9709283/8a44c97e-54ee-11e5-9af9-d26772eb97d1.png)
