### PR TITLE
Preserve nested, empty at-rules

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -77,7 +77,7 @@ function propertyLookup(options = defaultOptions) {
 
 
 function eachDecl(container, callback) {
-  container.nodes.forEach(node => {
+  container.each(node => {
     if (node.type === 'decl') {
       callback(node);
     }

--- a/test/test.js
+++ b/test/test.js
@@ -120,6 +120,11 @@ describe('postcss-property-lookup', function () {
     );
   });
 
+  it('preserves nested, empty at-rules', () => {
+    const css = 'a { @empty; }';
+    check(css, css);
+  });
+
   it('resolves a nested lookup', () => {
     check(
       `a {


### PR DESCRIPTION
This fixes an issue where errors were being thrown when encountering a mixin from [`postcss-mixins`](https://github.com/postcss/postcss-mixins).